### PR TITLE
fix: auth data JSON serialization bug in sendConnPkt()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -201,7 +201,7 @@ func (s *Socket) sendConnPkt() error {
 				data[k] = out[0].Interface()
 				continue
 			}
-			data[k] = v
+			data[k] = v.Interface()
 		}
 	}
 	if s.pid != "" {


### PR DESCRIPTION
The bug was causing auth values to be incorrectly serialized in the Socket.IO connection packet.  Direct string values were being stored as reflect.Value objects instead of their actual values, resulting in empty objects ({}) in the JSON output.

Changed `data[k] = v` to `data[k] = v.Interface()` to properly extract the underlying value before serialization.